### PR TITLE
Update Unit test for isolated Unit testing

### DIFF
--- a/src/Codeception/Test/Unit.php
+++ b/src/Codeception/Test/Unit.php
@@ -43,10 +43,14 @@ class Unit extends \Codeception\PHPUnit\TestCase implements
             return;
         }
 
+        try {
         /** @var $di Di  **/
         $di = $this->getMetadata()->getService('di');
         $di->set(new Scenario($this));
-
+        } catch (InjectionException $exception) {
+            $this->_before();
+            return;            
+        }
         // auto-inject $tester property
         if (($this->getMetadata()->getCurrent('actor')) && ($property = lcfirst(Configuration::config()['actor_suffix']))) {
             $this->$property = $di->instantiate($this->getMetadata()->getCurrent('actor'));


### PR DESCRIPTION
The `Di` should not be required when running a unit test. This caused issues in my setup when I tried to use `@dataProvider` in the Unit test.